### PR TITLE
Fixes for 'encryption.innodb_encryption_discard_import' MTR test case

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -4615,10 +4615,6 @@ sub run_testcase ($) {
   # -------------------------------------------------------
   my $timezone= timezone($tinfo);
   $ENV{'TZ'}= $timezone;
-  $ENV{MTR_SUITE_DIR} = $tinfo->{suite}->{dir};
-
-  mtr_verbose("MTR_SUITE_DIR: '$tinfo->{suite}->{dir}'");
-
   mtr_verbose("Setting timezone: $timezone");
 
   if ( ! using_extern() )

--- a/mysql-test/suite/encryption/r/innodb_encryption_discard_import.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_discard_import.result
@@ -1,33 +1,36 @@
-CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB encryption='ROTATED_KEYS';
+call mtr.add_suppression("\\[Warning\\] InnoDB: Tablespace for table `[^`]+`.`[^`]+` is set as discarded\\.");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Page [[:digit:]]+ at offset [[:digit:]]+ looks corrupted in file");
+call mtr.add_suppression("\\[ERROR\\] InnoDB: os_file_read\\(\\) failed");
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='ROTATED_KEYS';
 CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
-CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB COMPRESSION="zlib" encryption='ROTATED_KEYS';
+CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB COMPRESSION="zlib" ENCRYPTION='ROTATED_KEYS';
 CREATE TABLE t4 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB COMPRESSION="zlib";
-CREATE TABLE t5 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB row_format=compressed encryption='ROTATED_KEYS';
-CREATE TABLE t6 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB row_format=compressed;
+CREATE TABLE t5 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='ROTATED_KEYS';
+CREATE TABLE t6 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 CREATE TABLE t7 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='N';
 CREATE TABLE t8 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
-create procedure innodb_insert_proc (repeat_count int)
-begin
-declare current_num int;
-set current_num = 0;
-while current_num < repeat_count do
-insert into t1 values (current_num,repeat('foobar',42));
-insert into t2 values (current_num,repeat('temp', 42));
-insert into t3 values (current_num,repeat('barfoo',42));
-insert into t4 values (current_num,repeat('secret',42));
-insert into t5 values (current_num,repeat('fbar',42));
-insert into t6 values (current_num,repeat('barf',42));
-insert into t7 values (current_num,repeat('barb',42));
-insert into t8 values (current_num,repeat('baba',42));
-set current_num = current_num + 1;
-end while;
-end//
-commit;
-set autocommit=0;
-call innodb_insert_proc(10000);
-commit;
-set autocommit=1;
-# Wait max 10 min for key encryption threads to encrypt all spaces
+CREATE PROCEDURE innodb_insert_proc(repeat_count INT)
+BEGIN
+DECLARE current_num INT;
+SET current_num = 0;
+WHILE current_num < repeat_count DO
+INSERT INTO t1 VALUES (current_num, REPEAT('foobar', 42));
+INSERT INTO t2 VALUES (current_num, REPEAT('temp'  , 42));
+INSERT INTO t3 VALUES (current_num, REPEAT('barfoo', 42));
+INSERT INTO t4 VALUES (current_num, REPEAT('secret', 42));
+INSERT INTO t5 VALUES (current_num, REPEAT('fbar'  , 42));
+INSERT INTO t6 VALUES (current_num, REPEAT('barf'  , 42));
+INSERT INTO t7 VALUES (current_num, REPEAT('barb'  , 42));
+INSERT INTO t8 VALUES (current_num, REPEAT('baba'  , 42));
+SET current_num = current_num + 1;
+END WHILE;
+END//
+COMMIT;
+SET autocommit = 0;
+CALL innodb_insert_proc(10000);
+COMMIT;
+SET autocommit = 1;
+# Wait max 2 min for key encryption threads to encrypt all spaces
 include/assert.inc [Make sure t7 is not encrypted]
 # tablespaces should be now encrypted
 t1.frm
@@ -97,37 +100,21 @@ restore: t6 .ibd and .cfg files
 restore: t7 .ibd and .cfg files
 restore: t8 .ibd and .cfg files
 ALTER TABLE t1 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t1;
-COUNT(1)
-10000
+include/assert.inc [Make sure t1 is readable]
 ALTER TABLE t2 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t2;
-COUNT(1)
-10000
+include/assert.inc [Make sure t2 is readable]
 ALTER TABLE t3 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t3;
-COUNT(1)
-10000
+include/assert.inc [Make sure t3 is readable]
 ALTER TABLE t4 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t4;
-COUNT(1)
-10000
+include/assert.inc [Make sure t4 is readable]
 ALTER TABLE t5 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t5;
-COUNT(1)
-10000
+include/assert.inc [Make sure t5 is readable]
 ALTER TABLE t6 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t6;
-COUNT(1)
-10000
+include/assert.inc [Make sure t6 is readable]
 ALTER TABLE t7 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t7;
-COUNT(1)
-10000
+include/assert.inc [Make sure t7 is readable]
 ALTER TABLE t8 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t8;
-COUNT(1)
-10000
+include/assert.inc [Make sure t8 is readable]
 # tablespaces should remain encrypted after import, apart from t7
 ALTER TABLE t1 ENGINE InnoDB;
 SHOW CREATE TABLE t1;
@@ -136,7 +123,7 @@ t1	CREATE TABLE `t1` (
   `id` int(11) NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='ROTATED_KEYS'
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='ROTATED_KEYS' ENCRYPTION_KEY_ID=0
 ALTER TABLE t2 ENGINE InnoDB;
 SHOW CREATE TABLE t2;
 Table	Create Table
@@ -152,7 +139,7 @@ t3	CREATE TABLE `t3` (
   `id` int(11) NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMPRESSION='zlib' ENCRYPTION='ROTATED_KEYS'
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMPRESSION='zlib' ENCRYPTION='ROTATED_KEYS' ENCRYPTION_KEY_ID=0
 ALTER TABLE t4 ENGINE InnoDB;
 SHOW CREATE TABLE t4;
 Table	Create Table
@@ -160,7 +147,7 @@ t4	CREATE TABLE `t4` (
   `id` int(11) NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMPRESSION='zlib'
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMPRESSION='zlib' ENCRYPTION_KEY_ID=0
 ALTER TABLE t5 ENGINE InnoDB;
 SHOW CREATE TABLE t5;
 Table	Create Table
@@ -168,7 +155,7 @@ t5	CREATE TABLE `t5` (
   `id` int(11) NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED ENCRYPTION='ROTATED_KEYS'
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED ENCRYPTION='ROTATED_KEYS' ENCRYPTION_KEY_ID=0
 ALTER TABLE t6 ENGINE InnoDB;
 SHOW CREATE TABLE t6;
 Table	Create Table
@@ -176,7 +163,7 @@ t6	CREATE TABLE `t6` (
   `id` int(11) NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED ENCRYPTION_KEY_ID=0
 ALTER TABLE t7 ENGINE InnoDB;
 SHOW CREATE TABLE t7;
 Table	Create Table
@@ -192,37 +179,21 @@ t8	CREATE TABLE `t8` (
   `id` int(11) NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION_KEY_ID=0
 # Restarting server
 # restart
 # Done restarting server
 # Verify that tables are still usable
-SELECT COUNT(1) FROM t1;
-COUNT(1)
-10000
-SELECT COUNT(1) FROM t2;
-COUNT(1)
-10000
-SELECT COUNT(1) FROM t3;
-COUNT(1)
-10000
-SELECT COUNT(1) FROM t4;
-COUNT(1)
-10000
-SELECT COUNT(1) FROM t5;
-COUNT(1)
-10000
-SELECT COUNT(1) FROM t6;
-COUNT(1)
-10000
-SELECT COUNT(1) FROM t7;
-COUNT(1)
-10000
-SELECT COUNT(1) FROM t8;
-COUNT(1)
-10000
+include/assert.inc [Make sure t1 is readable]
+include/assert.inc [Make sure t2 is readable]
+include/assert.inc [Make sure t3 is readable]
+include/assert.inc [Make sure t4 is readable]
+include/assert.inc [Make sure t5 is readable]
+include/assert.inc [Make sure t6 is readable]
+include/assert.inc [Make sure t7 is readable]
+include/assert.inc [Make sure t8 is readable]
 # Tablespaces should be encrypted after restart
-include/assert.inc [Make sure all tables, apart from t2, are encrypted]
+include/assert.inc [Make sure all tables, apart from t7, are encrypted]
 t1.cfg
 t1.frm
 t1.ibd
@@ -299,157 +270,81 @@ restore: t7 .ibd and .cfg files
 restore: t8 .ibd and .cfg files
 # Disable rotation threads
 SET GLOBAL innodb_encryption_threads = 0;
-SET GLOBAL innodb_encrypt_tables = off;
+SET GLOBAL innodb_encrypt_tables = OFF;
 ALTER TABLE t1 IMPORT TABLESPACE;
 include/assert.inc [Make sure t1 has encrypted flag set after importing]
 include/assert.inc [Make sure t1 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
-SELECT COUNT(1) FROM t1;
-COUNT(1)
-10000
+include/assert.inc [Make sure t1 is readable]
 ALTER TABLE t2 IMPORT TABLESPACE;
 include/assert.inc [Make sure t2 has encrypted flag set after importing]
 include/assert.inc [Make sure t2 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
-SELECT COUNT(1) FROM t2;
-COUNT(1)
-10000
+include/assert.inc [Make sure t2 is readable]
 ALTER TABLE t3 IMPORT TABLESPACE;
 include/assert.inc [Make sure t3 has encrypted flag set after importing]
-SELECT COUNT(1) FROM t3;
-COUNT(1)
-10000
+include/assert.inc [Make sure t3 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t3 is readable]
 ALTER TABLE t4 IMPORT TABLESPACE;
 include/assert.inc [Make sure t4 has encrypted flag set after importing]
-SELECT COUNT(1) FROM t4;
-COUNT(1)
-10000
+include/assert.inc [Make sure t4 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t4 is readable]
 ALTER TABLE t5 IMPORT TABLESPACE;
 include/assert.inc [Make sure t5 has encrypted flag set after importing]
-SELECT COUNT(1) FROM t5;
-COUNT(1)
-10000
+include/assert.inc [Make sure t5 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t5 is readable]
 ALTER TABLE t6 IMPORT TABLESPACE;
 include/assert.inc [Make sure t6 has encrypted flag set after importing]
+include/assert.inc [Make sure t6 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t6 is readable]
 ALTER TABLE t7 IMPORT TABLESPACE;
 include/assert.inc [Make sure t7 does not have encrypted flag set after importing]
-SELECT COUNT(1) FROM t7;
-COUNT(1)
-10000
+include/assert.inc [Make sure t7 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)]
+include/assert.inc [Make sure t7 is readable]
 ALTER TABLE t8 IMPORT TABLESPACE;
 include/assert.inc [Make sure t8 has encrypted flag set after importing]
-SELECT COUNT(1) FROM t8;
-COUNT(1)
-10000
+include/assert.inc [Make sure t8 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t8 is readable]
 # tablespaces should be encrypted, apart from t7
 SET GLOBAL innodb_encryption_threads = 4;
-# Wait max 10 min for key encryption threads to decrypt all spaces, apart from t1, t3 and t5
+# Wait max 2 min for key encryption threads to decrypt all spaces, apart from t1, t3 and t5
 include/assert.inc [Make sure t1 has encrypted flag set]
 include/assert.inc [Make sure t1 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
-SELECT COUNT(1) FROM t1;
-COUNT(1)
-10000
+include/assert.inc [Make sure t1 is readable]
 include/assert.inc [Make sure t2 does not have encrypted flag set]
 include/assert.inc [Make sure t2 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0]
-SELECT COUNT(1) FROM t2;
-COUNT(1)
-10000
+include/assert.inc [Make sure t2 is readable]
 include/assert.inc [Make sure t3 has encrypted flag set]
-SELECT COUNT(1) FROM t3;
-COUNT(1)
-10000
+include/assert.inc [Make sure t3 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t3 is readable]
 include/assert.inc [Make sure t4 does not have encrypted flag set]
-SELECT COUNT(1) FROM t4;
-COUNT(1)
-10000
+include/assert.inc [Make sure t4 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0]
+include/assert.inc [Make sure t4 is readable]
 include/assert.inc [Make sure t5 has encrypted flag set]
-SELECT COUNT(1) FROM t5;
-COUNT(1)
-10000
+include/assert.inc [Make sure t5 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t5 is readable]
 include/assert.inc [Make sure t6 does not have encrypted flag set]
-SELECT COUNT(1) FROM t6;
-COUNT(1)
-10000
+include/assert.inc [Make sure t6 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0]
+include/assert.inc [Make sure t6 is readable]
 include/assert.inc [Make sure t7 does not have encrypted flag set]
-SELECT COUNT(1) FROM t7;
-COUNT(1)
-10000
+include/assert.inc [Make sure t7 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)]
+include/assert.inc [Make sure t7 is readable]
 include/assert.inc [Make sure t8 does not have encrypted flag set]
-SELECT COUNT(1) FROM t8;
-COUNT(1)
-10000
-SELECT * FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION;
-SPACE	NAME	ENCRYPTION_SCHEME	KEYSERVER_REQUESTS	MIN_KEY_VERSION	CURRENT_KEY_VERSION	KEY_ROTATION_PAGE_NUMBER	KEY_ROTATION_MAX_PAGE_NUMBER	CURRENT_KEY_ID	ROTATING_OR_FLUSHING
-2	mysql/plugin	0	0	0	0	NULL	NULL	0	0
-3	mysql/servers	0	0	0	0	NULL	NULL	0	0
-4	mysql/help_topic	0	0	0	0	NULL	NULL	0	0
-5	mysql/help_category	0	0	0	0	NULL	NULL	0	0
-6	mysql/help_relation	0	0	0	0	NULL	NULL	0	0
-7	mysql/help_keyword	0	0	0	0	NULL	NULL	0	0
-8	mysql/time_zone_name	0	0	0	0	NULL	NULL	0	0
-9	mysql/time_zone	0	0	0	0	NULL	NULL	0	0
-10	mysql/time_zone_transition	0	0	0	0	NULL	NULL	0	0
-11	mysql/time_zone_transition_type	0	0	0	0	NULL	NULL	0	0
-12	mysql/time_zone_leap_second	0	0	0	0	NULL	NULL	0	0
-13	mysql/innodb_table_stats	0	0	0	0	NULL	NULL	0	0
-14	mysql/innodb_index_stats	0	0	0	0	NULL	NULL	0	0
-15	mysql/slave_relay_log_info	0	0	0	0	NULL	NULL	0	0
-16	mysql/slave_master_info	0	0	0	0	NULL	NULL	0	0
-17	mysql/slave_worker_info	0	0	0	0	NULL	NULL	0	0
-18	mysql/gtid_executed	0	0	0	0	NULL	NULL	0	0
-19	mysql/server_cost	0	0	0	0	NULL	NULL	0	0
-20	mysql/engine_cost	0	0	0	0	NULL	NULL	0	0
-21	sys/sys_config	0	0	0	0	NULL	NULL	0	0
-31	test/t1	1	0	1	1	NULL	NULL	0	0
-32	test/t2	0	0	0	0	NULL	NULL	0	0
-33	test/t3	1	0	1	1	NULL	NULL	0	0
-34	test/t4	0	0	0	0	NULL	NULL	0	0
-35	test/t5	1	0	1	1	NULL	NULL	0	0
-36	test/t6	0	0	0	0	NULL	NULL	0	0
-37	test/t7	0	0	0	0	NULL	NULL	0	0
-38	test/t8	0	0	0	0	NULL	NULL	0	0
-0	innodb_system	0	0	0	0	NULL	NULL	0	0
-SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES;
-SPACE	NAME	FLAG	FILE_FORMAT	ROW_FORMAT	PAGE_SIZE	ZIP_PAGE_SIZE	SPACE_TYPE	FS_BLOCK_SIZE	FILE_SIZE	ALLOCATED_SIZE
-2	mysql/plugin	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-3	mysql/servers	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-4	mysql/help_topic	33	Barracuda	Dynamic	16384	0	Single	4096	114688	114688
-5	mysql/help_category	33	Barracuda	Dynamic	16384	0	Single	4096	114688	114688
-6	mysql/help_relation	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-7	mysql/help_keyword	33	Barracuda	Dynamic	16384	0	Single	4096	114688	114688
-8	mysql/time_zone_name	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-9	mysql/time_zone	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-10	mysql/time_zone_transition	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-11	mysql/time_zone_transition_type	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-12	mysql/time_zone_leap_second	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-13	mysql/innodb_table_stats	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-14	mysql/innodb_index_stats	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-15	mysql/slave_relay_log_info	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-16	mysql/slave_master_info	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-17	mysql/slave_worker_info	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-18	mysql/gtid_executed	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-19	mysql/server_cost	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-20	mysql/engine_cost	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-21	sys/sys_config	33	Barracuda	Dynamic	16384	0	Single	4096	98304	98304
-31	test/t1	8225	Barracuda	Dynamic	16384	0	Single	4096	9437184	9437184
-32	test/t2	33	Barracuda	Dynamic	16384	0	Single	4096	8388608	8388608
-33	test/t3	8225	Barracuda	Dynamic	16384	0	Single	4096	9437184	9437184
-34	test/t4	33	Barracuda	Dynamic	16384	0	Single	4096	9437184	9437184
-35	test/t5	8233	Barracuda	Compressed	16384	8192	Single	4096	4194304	4194304
-36	test/t6	41	Barracuda	Compressed	16384	8192	Single	4096	4194304	4194304
-37	test/t7	33	Barracuda	Dynamic	16384	0	Single	4096	8388608	8388608
-38	test/t8	33	Barracuda	Dynamic	16384	0	Single	4096	8388608	8388608
+include/assert.inc [Make sure t8 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0]
+include/assert.inc [Make sure t8 is readable]
 # tablespaces should not be encrypted, apart from t1,t3 and t5
 # Now let's backup keyring file, change encryption key id of encrypt-able tables (all but t7) 
 # export and dicard them. Next restart the server with backuped keyring file and make sure that
 # server starts, but tables cannot be imported gracefully
-SET GLOBAL innodb_encrypt_tables = on;
-# Wait max 10 min for key encryption threads to encrypt all spaces
-ALTER TABLE t1 encryption_key_id=5;
-ALTER TABLE t2 encryption_key_id=5;
-ALTER TABLE t3 encryption_key_id=5;
-ALTER TABLE t4 encryption_key_id=5;
-ALTER TABLE t5 encryption_key_id=5;
-ALTER TABLE t6 encryption_key_id=5;
-ALTER TABLE t8 encryption_key_id=5;
+SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+# Wait max 2 min for key encryption threads to encrypt all spaces
+ALTER TABLE t1 encryption_key_id = 5;
+ALTER TABLE t2 encryption_key_id = 5;
+Warnings:
+Warning	140	InnoDB: Ignored ENCRYPTION_KEY_ID 5 when Master Key encryption is enabled.
+ALTER TABLE t3 encryption_key_id = 5;
+ALTER TABLE t4 encryption_key_id = 5;
+ALTER TABLE t5 encryption_key_id = 5;
+ALTER TABLE t6 encryption_key_id = 5;
+ALTER TABLE t8 encryption_key_id = 5;
 t1.cfg
 t1.frm
 t1.ibd
@@ -521,21 +416,22 @@ restore: t4 .ibd and .cfg files
 restore: t5 .ibd and .cfg files
 restore: t6 .ibd and .cfg files
 restore: t8 .ibd and .cfg files
-# restart:--loose-keyring_file_data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/tmp/mysecret_keyring_backup
+# restart:--loose-keyring_file_data=/home/yura/addon/percona-build-5.7-debug_min/mysql-test/var/tmp/mysecret_keyring_backup
 ALTER TABLE t1 IMPORT TABLESPACE;
-ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
+ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t1` : Data structure corruption
 ALTER TABLE t2 IMPORT TABLESPACE;
-ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 't2'
 ALTER TABLE t3 IMPORT TABLESPACE;
-ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
+ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t3` : Page decompress failed after reading from disk
 ALTER TABLE t4 IMPORT TABLESPACE;
-ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
+ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t4` : Page decompress failed after reading from disk
 ALTER TABLE t5 IMPORT TABLESPACE;
-ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
+ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t5` : Data structure corruption
 ALTER TABLE t6 IMPORT TABLESPACE;
-ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
+ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t6` : Data structure corruption
 ALTER TABLE t8 IMPORT TABLESPACE;
-ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
-# restart:--loose-keyring_file_data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/tmp/mysecret_keyring
+ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t8` : Data structure corruption
+# restart:--loose-keyring_file_data=/home/yura/addon/percona-build-5.7-debug_min/mysql-test/var/tmp/mysecret_keyring
 DROP PROCEDURE innodb_insert_proc;
 DROP TABLE t1, t2, t3, t4, t5, t6, t7, t8;

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change2.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change2.test
@@ -54,8 +54,6 @@ SHOW WARNINGS;
 SET GLOBAL innodb_stats_persistent=OFF;
 let MYSQLD_DATADIR =`SELECT @@datadir`;
 
-#--echo $MTR_SUITE_DIR
-
 FLUSH TABLES t1 FOR EXPORT;
 perl;
 do "$ENV{MYSQL_TEST_DIR}/suite/encryption/include/innodb-util.pl";

--- a/mysql-test/suite/encryption/t/innodb_encryption_discard_import-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_discard_import-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ON
+--innodb-encrypt-tables=ONLINE_TO_KEYRING
 --innodb-encryption-threads=4

--- a/mysql-test/suite/encryption/t/innodb_encryption_discard_import.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption_discard_import.test
@@ -1,111 +1,110 @@
 --source include/have_innodb.inc
-#-- source include/have_example_key_management_plugin.inc
 --source include/not_valgrind.inc
 --source include/not_embedded.inc
 
-let MYSQLD_DATADIR = `SELECT @@datadir`;
+call mtr.add_suppression("\\[Warning\\] InnoDB: Tablespace for table `[^`]+`.`[^`]+` is set as discarded\\.");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Page [[:digit:]]+ at offset [[:digit:]]+ looks corrupted in file");
+call mtr.add_suppression("\\[ERROR\\] InnoDB: os_file_read\\(\\) failed");
 
---let $id = `SELECT RAND()`
---let t1_IBD = $MYSQLD_DATADIR/test/t1.ibd
---let t2_IBD = $MYSQLD_DATADIR/test/t2.ibd
---let t3_IBD = $MYSQLD_DATADIR/test/t3.ibd
---let t4_IBD = $MYSQLD_DATADIR/test/t4.ibd
---let t5_IBD = $MYSQLD_DATADIR/test/t5.ibd
---let t6_IBD = $MYSQLD_DATADIR/test/t6.ibd
---let t7_IBD = $MYSQLD_DATADIR/test/t7.ibd
---let t8_IBD = $MYSQLD_DATADIR/test/t8.ibd
+--let $number_of_records = 10000
+--let MYSQLD_DATADIR = `SELECT @@datadir`
 
-CREATE TABLESPACE ts_valid2 ADD DATAFILE 'ts_valid2.ibd' ENCRYPTION='ROTATED_KEYS';
+--let DB_NAME = `SELECT DATABASE()`
+--let $t1_ibd = $MYSQLD_DATADIR/$DB_NAME/t1.ibd
+--let $t2_ibd = $MYSQLD_DATADIR/$DB_NAME/t2.ibd
+--let $t3_ibd = $MYSQLD_DATADIR/$DB_NAME/t3.ibd
+--let $t4_ibd = $MYSQLD_DATADIR/$DB_NAME/t4.ibd
+--let $t5_ibd = $MYSQLD_DATADIR/$DB_NAME/t5.ibd
+--let $t6_ibd = $MYSQLD_DATADIR/$DB_NAME/t6.ibd
+--let $t7_ibd = $MYSQLD_DATADIR/$DB_NAME/t7.ibd
+--let $t8_ibd = $MYSQLD_DATADIR/$DB_NAME/t8.ibd
 
-
-CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB encryption='ROTATED_KEYS';
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='ROTATED_KEYS';
 CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
-CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB COMPRESSION="zlib" encryption='ROTATED_KEYS';
+CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB COMPRESSION="zlib" ENCRYPTION='ROTATED_KEYS';
 CREATE TABLE t4 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB COMPRESSION="zlib";
-CREATE TABLE t5 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB row_format=compressed encryption='ROTATED_KEYS';
-CREATE TABLE t6 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB row_format=compressed;
+CREATE TABLE t5 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='ROTATED_KEYS';
+CREATE TABLE t6 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 CREATE TABLE t7 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='N';
 CREATE TABLE t8 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
 
 delimiter //;
-create procedure innodb_insert_proc (repeat_count int)
-begin
-  declare current_num int;
-  set current_num = 0;
-  while current_num < repeat_count do
-    insert into t1 values (current_num,repeat('foobar',42));
-    insert into t2 values (current_num,repeat('temp', 42));
-    insert into t3 values (current_num,repeat('barfoo',42));
-    insert into t4 values (current_num,repeat('secret',42));
-    insert into t5 values (current_num,repeat('fbar',42));
-    insert into t6 values (current_num,repeat('barf',42));
-    insert into t7 values (current_num,repeat('barb',42));
-    insert into t8 values (current_num,repeat('baba',42));
-    set current_num = current_num + 1;
-  end while;
-end//
+CREATE PROCEDURE innodb_insert_proc(repeat_count INT)
+BEGIN
+  DECLARE current_num INT;
+  SET current_num = 0;
+  WHILE current_num < repeat_count DO
+    INSERT INTO t1 VALUES (current_num, REPEAT('foobar', 42));
+    INSERT INTO t2 VALUES (current_num, REPEAT('temp'  , 42));
+    INSERT INTO t3 VALUES (current_num, REPEAT('barfoo', 42));
+    INSERT INTO t4 VALUES (current_num, REPEAT('secret', 42));
+    INSERT INTO t5 VALUES (current_num, REPEAT('fbar'  , 42));
+    INSERT INTO t6 VALUES (current_num, REPEAT('barf'  , 42));
+    INSERT INTO t7 VALUES (current_num, REPEAT('barb'  , 42));
+    INSERT INTO t8 VALUES (current_num, REPEAT('baba'  , 42));
+    SET current_num = current_num + 1;
+  END WHILE;
+END//
 delimiter ;//
-commit;
+COMMIT;
 
-set autocommit=0;
-call innodb_insert_proc(10000);
-commit;
-set autocommit=1;
+SET autocommit = 0;
+eval CALL innodb_insert_proc($number_of_records);
+COMMIT;
+SET autocommit = 1;
 
-#--sleep 40
-#SELECT NAME, MIN_KEY_VERSION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0;
+--let $tables_count = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES`
 
---let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES`
-
---echo # Wait max 10 min for key encryption threads to encrypt all spaces
---let $wait_timeout= 600
-# All tables should get encrypted. $tables_count - because INNODB_TABLESPACES_ENCRYPTION contains artificial innodb_system
-# table and t7 is unencrypted
---let $wait_condition=SELECT COUNT(*) = $tables_count FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--echo # Wait max 2 min for key encryption threads to encrypt all spaces
+--let $wait_timeout = 120
+# All tables should get encrypted. Exactly ($tables_count) because
+# INNODB_TABLESPACES_ENCRYPTION contains artificial 'innodb_system' (+1)
+# table and 't7' is unencrypted (-1).
+--let $wait_condition = SELECT COUNT(*) = $tables_count FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
 --source include/wait_condition.inc
 
---let $assert_text= Make sure t7 is not encrypted
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 and name=\\'test/t7\\']" = 1
+--let $assert_text = Make sure t7 is not encrypted
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t7"] = 1
 --source include/assert.inc
 
 --echo # tablespaces should be now encrypted
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=foobar
---let SEARCH_FILE=$t1_IBD
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = foobar
+--let SEARCH_FILE = $t1_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=temp
---let SEARCH_FILE=$t2_IBD
+--let SEARCH_PATTERN = temp
+--let SEARCH_FILE = $t2_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=barfoo
---let SEARCH_FILE=$t3_IBD
+--let SEARCH_PATTERN = barfoo
+--let SEARCH_FILE = $t3_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=secret
---let SEARCH_FILE=$t4_IBD
+--let SEARCH_PATTERN = secret
+--let SEARCH_FILE = $t4_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=fbar
---let SEARCH_FILE=$t5_IBD
+--let SEARCH_PATTERN = fbar
+--let SEARCH_FILE = $t5_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=barf
---let SEARCH_FILE=$t6_IBD
+--let SEARCH_PATTERN = barf
+--let SEARCH_FILE = $t6_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=NOT_FOUND
---let SEARCH_PATTERN=barb
---let SEARCH_FILE=$t7_IBD
+--let ABORT_ON = NOT_FOUND
+--let SEARCH_PATTERN = barb
+--let SEARCH_FILE = $t7_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=baba
---let SEARCH_FILE=$t8_IBD
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = baba
+--let SEARCH_FILE = $t8_ibd
 --source include/search_pattern_in_file.inc
 
 
---list_files $MYSQLD_DATADIR/test
+--list_files $MYSQLD_DATADIR/$DB_NAME
 FLUSH TABLES t1, t2, t3, t4, t5, t6, t7, t8 FOR EXPORT;
 
-perl;
+--perl
 do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
-ib_backup_tablespaces("test", "t1","t2","t3", "t4", "t5", "t6", "t7", "t8");
+ib_backup_tablespaces("$ENV{DB_NAME}", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8");
 EOF
---list_files $MYSQLD_DATADIR/test
+--list_files $MYSQLD_DATADIR/$DB_NAME
 UNLOCK TABLES;
 
 ALTER TABLE t1 DISCARD TABLESPACE;
@@ -117,56 +116,79 @@ ALTER TABLE t6 DISCARD TABLESPACE;
 ALTER TABLE t7 DISCARD TABLESPACE;
 ALTER TABLE t8 DISCARD TABLESPACE;
 
-perl;
+--perl
 do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
-ib_discard_tablespaces("test", "t1","t2","t3","t4","t5","t6","t7","t8");
-ib_restore_tablespaces("test", "t1","t2","t3","t4","t5","t6","t7","t8");
+ib_discard_tablespaces("$ENV{DB_NAME}", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8");
+ib_restore_tablespaces("$ENV{DB_NAME}", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8");
 EOF
 
 ALTER TABLE t1 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t1;
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t2 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t2;
+--let $assert_text = Make sure t2 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t2] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t3 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t3;
+--let $assert_text = Make sure t3 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t3] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t4 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t4;
+--let $assert_text = Make sure t4 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t4] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t5 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t5;
+--let $assert_text = Make sure t5 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t5] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t6 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t6;
+--let $assert_text = Make sure t6 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t6] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t7 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t7;
+--let $assert_text = Make sure t7 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t7] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t8 IMPORT TABLESPACE;
-SELECT COUNT(1) FROM t8;
+--let $assert_text = Make sure t8 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t8] = $number_of_records
+--source include/assert.inc
 
 --echo # tablespaces should remain encrypted after import, apart from t7
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=foobar
---let SEARCH_FILE=$t1_IBD
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = foobar
+--let SEARCH_FILE = $t1_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=temp
---let SEARCH_FILE=$t2_IBD
+--let SEARCH_PATTERN = temp
+--let SEARCH_FILE = $t2_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=barfoo
---let SEARCH_FILE=$t3_IBD
+--let SEARCH_PATTERN = barfoo
+--let SEARCH_FILE = $t3_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=secret
---let SEARCH_FILE=$t4_IBD
+--let SEARCH_PATTERN = secret
+--let SEARCH_FILE = $t4_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=fbar
---let SEARCH_FILE=$t5_IBD
+--let SEARCH_PATTERN = fbar
+--let SEARCH_FILE = $t5_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=barf
---let SEARCH_FILE=$t6_IBD
+--let SEARCH_PATTERN = barf
+--let SEARCH_FILE = $t6_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=NOT_FOUND
---let SEARCH_PATTERN=barb
---let SEARCH_FILE=$t7_IBD
+--let ABORT_ON = NOT_FOUND
+--let SEARCH_PATTERN = barb
+--let SEARCH_FILE = $t7_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=baba
---let SEARCH_FILE=$t8_IBD
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = baba
+--let SEARCH_FILE = $t8_ibd
 --source include/search_pattern_in_file.inc
 
 
@@ -188,61 +210,77 @@ ALTER TABLE t8 ENGINE InnoDB;
 SHOW CREATE TABLE t8;
 
 --echo # Restarting server
--- source include/restart_mysqld.inc
+--source include/restart_mysqld.inc
 --echo # Done restarting server
 
 --echo # Verify that tables are still usable
-SELECT COUNT(1) FROM t1;
-SELECT COUNT(1) FROM t2;
-SELECT COUNT(1) FROM t3;
-SELECT COUNT(1) FROM t4;
-SELECT COUNT(1) FROM t5;
-SELECT COUNT(1) FROM t6;
-SELECT COUNT(1) FROM t7;
-SELECT COUNT(1) FROM t8;
-
---echo # Tablespaces should be encrypted after restart
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=foobar
---let SEARCH_FILE=$t1_IBD
---source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=temp
---let SEARCH_FILE=$t2_IBD
---source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=barfoo
---let SEARCH_FILE=$t3_IBD
---source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=secret
---let SEARCH_FILE=$t4_IBD
---source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=fbar
---let SEARCH_FILE=$t5_IBD
---source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=barf
---let SEARCH_FILE=$t6_IBD
---source include/search_pattern_in_file.inc
---let ABORT_ON=NOT_FOUND
---let SEARCH_PATTERN=barb
---let SEARCH_FILE=$t7_IBD
---source include/search_pattern_in_file.inc
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=baba
---let SEARCH_FILE=$t8_IBD
---source include/search_pattern_in_file.inc
-
-
---let $assert_text= Make sure all tables, apart from t2, are encrypted
---let $assert_cond= "[SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0]" = 1
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+--let $assert_text = Make sure t2 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t2] = $number_of_records
+--source include/assert.inc
+--let $assert_text = Make sure t3 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t3] = $number_of_records
+--source include/assert.inc
+--let $assert_text = Make sure t4 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t4] = $number_of_records
+--source include/assert.inc
+--let $assert_text = Make sure t5 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t5] = $number_of_records
+--source include/assert.inc
+--let $assert_text = Make sure t6 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t6] = $number_of_records
+--source include/assert.inc
+--let $assert_text = Make sure t7 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t7] = $number_of_records
+--source include/assert.inc
+--let $assert_text = Make sure t8 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t8] = $number_of_records
 --source include/assert.inc
 
---list_files $MYSQLD_DATADIR/test
+--echo # Tablespaces should be encrypted after restart
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = foobar
+--let SEARCH_FILE = $t1_ibd
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN = temp
+--let SEARCH_FILE = $t2_ibd
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN = barfoo
+--let SEARCH_FILE = $t3_ibd
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN = secret
+--let SEARCH_FILE = $t4_ibd
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN = fbar
+--let SEARCH_FILE = $t5_ibd
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN = barf
+--let SEARCH_FILE = $t6_ibd
+--source include/search_pattern_in_file.inc
+--let ABORT_ON = NOT_FOUND
+--let SEARCH_PATTERN = barb
+--let SEARCH_FILE = $t7_ibd
+--source include/search_pattern_in_file.inc
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = baba
+--let SEARCH_FILE = $t8_ibd
+--source include/search_pattern_in_file.inc
+
+
+--let $assert_text = Make sure all tables, apart from t7, are encrypted
+--let $assert_cond = "[SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0]" = 1
+--source include/assert.inc
+
+--list_files $MYSQLD_DATADIR/$DB_NAME
 FLUSH TABLES t1, t2, t3, t4, t5, t6, t7, t8 FOR EXPORT;
 
-perl;
+--perl
 do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
-ib_backup_tablespaces("test", "t1","t2","t3", "t4", "t5", "t6", "t7", "t8");
+ib_backup_tablespaces("$ENV{DB_NAME}", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8");
 EOF
---list_files $MYSQLD_DATADIR/test
+--list_files $MYSQLD_DATADIR/$DB_NAME
 UNLOCK TABLES;
 
 ALTER TABLE t1 DISCARD TABLESPACE;
@@ -254,226 +292,283 @@ ALTER TABLE t6 DISCARD TABLESPACE;
 ALTER TABLE t7 DISCARD TABLESPACE;
 ALTER TABLE t8 DISCARD TABLESPACE;
 
-perl;
+--perl
 do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
-ib_discard_tablespaces("test", "t1","t2","t3","t4","t5","t6","t7","t8");
-ib_restore_tablespaces("test", "t1","t2","t3","t4","t5","t6","t7","t8");
+ib_discard_tablespaces("$ENV{DB_NAME}", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8");
+ib_restore_tablespaces("$ENV{DB_NAME}", "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8");
 EOF
 
 --echo # Disable rotation threads
 SET GLOBAL innodb_encryption_threads = 0;
-SET GLOBAL innodb_encrypt_tables = off;
+SET GLOBAL innodb_encrypt_tables = OFF;
 
 ALTER TABLE t1 IMPORT TABLESPACE;
---let $assert_text= Make sure t1 has encrypted flag set after importing
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t1\\']" = 8192
+--let $assert_text = Make sure t1 has encrypted flag set after importing
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t1"] = 8192
 --source include/assert.inc
---let $assert_text= Make sure t1 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME=\\'test/t1\\']" = 1
+--let $assert_text = Make sure t1 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t1"] = 1
 --source include/assert.inc
-SELECT COUNT(1) FROM t1;
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t2 IMPORT TABLESPACE;
---let $assert_text= Make sure t2 has encrypted flag set after importing
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t2\\']" = 8192
+--let $assert_text = Make sure t2 has encrypted flag set after importing
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t2"] = 8192
 --source include/assert.inc
---let $assert_text= Make sure t2 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME=\\'test/t2\\']" = 1
+--let $assert_text = Make sure t2 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t2"] = 1
 --source include/assert.inc
-SELECT COUNT(1) FROM t2;
+--let $assert_text = Make sure t2 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t2] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t3 IMPORT TABLESPACE;
---let $assert_text= Make sure t3 has encrypted flag set after importing
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t3\\']" = 8192
+--let $assert_text = Make sure t3 has encrypted flag set after importing
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t3"] = 8192
 --source include/assert.inc
---let $assert_text= Make sure t3 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME=\\'test/t3\\']" = 1
-SELECT COUNT(1) FROM t3;
+--let $assert_text = Make sure t3 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t3"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t3 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t3] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t4 IMPORT TABLESPACE;
---let $assert_text= Make sure t4 has encrypted flag set after importing
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t4\\']" = 8192
+--let $assert_text = Make sure t4 has encrypted flag set after importing
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t4"] = 8192
 --source include/assert.inc
---let $assert_text= Make sure t4 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME=\\'test/t4\\']" = 1
-SELECT COUNT(1) FROM t4;
+--let $assert_text = Make sure t4 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t4"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t4 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t4] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t5 IMPORT TABLESPACE;
---let $assert_text= Make sure t5 has encrypted flag set after importing
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t5\\']" = 8192
+--let $assert_text = Make sure t5 has encrypted flag set after importing
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t5"] = 8192
 --source include/assert.inc
---let $assert_text= Make sure t5 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME=\\'test/t5\\']" = 1
-SELECT COUNT(1) FROM t5;
+--let $assert_text = Make sure t5 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t5"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t5 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t5] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t6 IMPORT TABLESPACE;
---let $assert_text= Make sure t6 has encrypted flag set after importing
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t6\\']" = 8192
+--let $assert_text = Make sure t6 has encrypted flag set after importing
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t6"] = 8192
 --source include/assert.inc
---let $assert_text= Make sure t6 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME=\\'test/t6\\']" = 1
+--let $assert_text = Make sure t6 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t6"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t6 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t6] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t7 IMPORT TABLESPACE;
---let $assert_text= Make sure t7 does not have encrypted flag set after importing
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t7\\']" = 0
+--let $assert_text = Make sure t7 does not have encrypted flag set after importing
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t7"] = 0
 --source include/assert.inc
---let $assert_text= Make sure t7 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME=\\'test/t7\\']" = 1
-SELECT COUNT(1) FROM t7;
+--let $assert_text = Make sure t7 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t7"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t7 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t7] = $number_of_records
+--source include/assert.inc
+
 ALTER TABLE t8 IMPORT TABLESPACE;
---let $assert_text= Make sure t8 has encrypted flag set after importing
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t8\\']" = 8192
+--let $assert_text = Make sure t8 has encrypted flag set after importing
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t8"] = 8192
 --source include/assert.inc
---let $assert_text= Make sure t8 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME=\\'test/t8\\']" = 1
-SELECT COUNT(1) FROM t8;
+--let $assert_text = Make sure t8 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t8"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t8 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t8] = $number_of_records
+--source include/assert.inc
 
 --echo # tablespaces should be encrypted, apart from t7
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=foobar
---let SEARCH_FILE=$t1_IBD
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = foobar
+--let SEARCH_FILE = $t1_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=temp
---let SEARCH_FILE=$t2_IBD
+--let SEARCH_PATTERN = temp
+--let SEARCH_FILE = $t2_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=barfoo
---let SEARCH_FILE=$t3_IBD
+--let SEARCH_PATTERN = barfoo
+--let SEARCH_FILE = $t3_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=secret
---let SEARCH_FILE=$t4_IBD
+--let SEARCH_PATTERN = secret
+--let SEARCH_FILE = $t4_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=fbar
---let SEARCH_FILE=$t5_IBD
+--let SEARCH_PATTERN = fbar
+--let SEARCH_FILE = $t5_ibd
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=barf
---let SEARCH_FILE=$t6_IBD
+--let SEARCH_PATTERN = barf
+--let SEARCH_FILE = $t6_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=NOT_FOUND
---let SEARCH_PATTERN=barb
---let SEARCH_FILE=$t7_IBD
+--let ABORT_ON = NOT_FOUND
+--let SEARCH_PATTERN = barb
+--let SEARCH_FILE = $t7_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=baba
---let SEARCH_FILE=$t8_IBD
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = baba
+--let SEARCH_FILE = $t8_ibd
 --source include/search_pattern_in_file.inc
 
 SET GLOBAL innodb_encryption_threads = 4;
 
---echo # Wait max 10 min for key encryption threads to decrypt all spaces, apart from t1, t3 and t5
---let $wait_timeout= 600
---let $wait_condition=SELECT COUNT(*) = 3 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+--echo # Wait max 2 min for key encryption threads to decrypt all spaces, apart from t1, t3 and t5
+--let $wait_timeout = 120
+--let $wait_condition = SELECT COUNT(*) = 3 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
---let $assert_text= Make sure t1 has encrypted flag set
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t1\\']" = 8192
+--let $assert_text = Make sure t1 has encrypted flag set
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t1"] = 8192
 --source include/assert.inc
---let $assert_text= Make sure t1 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME=\\'test/t1\\']" = 1
+--let $assert_text = Make sure t1 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t1"] = 1
 --source include/assert.inc
-SELECT COUNT(1) FROM t1;
---let $assert_text= Make sure t2 does not have encrypted flag set
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t2\\']" = 0
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
 --source include/assert.inc
---let $assert_text= Make sure t2 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME=\\'test/t2\\']" = 1
---source include/assert.inc
-SELECT COUNT(1) FROM t2;
---let $assert_text= Make sure t3 has encrypted flag set
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t3\\']" = 8192
---source include/assert.inc
---let $assert_text= Make sure t3 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME=\\'test/t3\\']" = 1
-SELECT COUNT(1) FROM t3;
---let $assert_text= Make sure t4 does not have encrypted flag set
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t4\\']" = 0
---source include/assert.inc
---let $assert_text= Make sure t4 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME=\\'test/t4\\']" = 1
-SELECT COUNT(1) FROM t4;
---let $assert_text= Make sure t5 has encrypted flag set
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t5\\']" = 8192
---source include/assert.inc
---let $assert_text= Make sure t5 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME=\\'test/t5\\']" = 1
-SELECT COUNT(1) FROM t5;
---let $assert_text= Make sure t6 does not have encrypted flag set
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t6\\']" = 0
---source include/assert.inc
---let $assert_text= Make sure t6 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME=\\'test/t6\\']" = 1
-SELECT COUNT(1) FROM t6;
---let $assert_text= Make sure t7 does not have encrypted flag set
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t7\\']" = 0
---source include/assert.inc
---let $assert_text= Make sure t7 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME=\\'test/t7\\']" = 1
-SELECT COUNT(1) FROM t7;
---let $assert_text= Make sure t8 does not have encrypted flag set
---let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME=\\'test/t8\\']" = 0
---source include/assert.inc
---let $assert_text= Make sure t8 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME=\\'test/t8\\']" = 1
-SELECT COUNT(1) FROM t8;
 
-SELECT * FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION;
-SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES;
+--let $assert_text = Make sure t2 does not have encrypted flag set
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t2"] = 0
+--source include/assert.inc
+--let $assert_text = Make sure t2 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t2"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t2 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t2] = $number_of_records
+--source include/assert.inc
+
+--let $assert_text = Make sure t3 has encrypted flag set
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t3"] = 8192
+--source include/assert.inc
+--let $assert_text = Make sure t3 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t3"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t3 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t3] = $number_of_records
+--source include/assert.inc
+
+--let $assert_text = Make sure t4 does not have encrypted flag set
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t4"] = 0
+--source include/assert.inc
+--let $assert_text = Make sure t4 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t4"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t4 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t4] = $number_of_records
+--source include/assert.inc
+
+--let $assert_text = Make sure t5 has encrypted flag set
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t5"] = 8192
+--source include/assert.inc
+--let $assert_text = Make sure t5 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t5"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t5 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t5] = $number_of_records
+--source include/assert.inc
+
+--let $assert_text = Make sure t6 does not have encrypted flag set
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t6"] = 0
+--source include/assert.inc
+--let $assert_text = Make sure t6 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t6"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t6 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t6] = $number_of_records
+--source include/assert.inc
+
+--let $assert_text = Make sure t7 does not have encrypted flag set
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t7"] = 0
+--source include/assert.inc
+--let $assert_text = Make sure t7 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t7"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t7 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t7] = $number_of_records
+--source include/assert.inc
+
+--let $assert_text = Make sure t8 does not have encrypted flag set
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t8"] = 0
+--source include/assert.inc
+--let $assert_text = Make sure t8 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t8"] = 1
+--source include/assert.inc
+--let $assert_text = Make sure t8 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t8] = $number_of_records
+--source include/assert.inc
 
 --echo # tablespaces should not be encrypted, apart from t1,t3 and t5
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=foobar
---let SEARCH_FILE=$t1_IBD
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = foobar
+--let SEARCH_FILE = $t1_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=NOT_FOUND
---let SEARCH_PATTERN=temp
---let SEARCH_FILE=$t2_IBD
+--let ABORT_ON = NOT_FOUND
+--let SEARCH_PATTERN = temp
+--let SEARCH_FILE = $t2_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=barfoo
---let SEARCH_FILE=$t3_IBD
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = barfoo
+--let SEARCH_FILE = $t3_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=NOT_FOUND
---let SEARCH_PATTERN=secret
---let SEARCH_FILE=$t4_IBD
+--let ABORT_ON = NOT_FOUND
+--let SEARCH_PATTERN = secret
+--let SEARCH_FILE = $t4_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=FOUND
---let SEARCH_PATTERN=fbar
---let SEARCH_FILE=$t5_IBD
+--let ABORT_ON = FOUND
+--let SEARCH_PATTERN = fbar
+--let SEARCH_FILE = $t5_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=NOT_FOUND
---let SEARCH_PATTERN=barb
+--let ABORT_ON = NOT_FOUND
+--let SEARCH_PATTERN = barb
 # t6 is not encrypted, but unreadable as it is compressed
---let SEARCH_FILE=$t7_IBD
+--let SEARCH_FILE = $t7_ibd
 --source include/search_pattern_in_file.inc
---let ABORT_ON=NOT_FOUND
---let SEARCH_PATTERN=baba
---let SEARCH_FILE=$t8_IBD
+--let ABORT_ON = NOT_FOUND
+--let SEARCH_PATTERN = baba
+--let SEARCH_FILE = $t8_ibd
 --source include/search_pattern_in_file.inc
 
 --echo # Now let's backup keyring file, change encryption key id of encrypt-able tables (all but t7) 
 --echo # export and dicard them. Next restart the server with backuped keyring file and make sure that
 --echo # server starts, but tables cannot be imported gracefully
 
-SET GLOBAL innodb_encrypt_tables = on;
+SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
 
---echo # Wait max 10 min for key encryption threads to encrypt all spaces
---let $wait_timeout= 600
-# All tables should get encrypted. $tables_count - because INNODB_TABLESPACES_ENCRYPTION contains artificial innodb_system
-# table and t7 is unencrypted
---let $wait_condition=SELECT COUNT(*) = $tables_count FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--echo # Wait max 2 min for key encryption threads to encrypt all spaces
+--let $wait_timeout = 120
+# All tables should get encrypted. Exactly ($tables_count) because
+# INNODB_TABLESPACES_ENCRYPTION contains artificial 'innodb_system' (+1)
+# table and 't7' is unencrypted (-1).
+--let $wait_condition = SELECT COUNT(*) = $tables_count FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
 --source include/wait_condition.inc
 
 --copy_file $MYSQLTEST_VARDIR/tmp/mysecret_keyring $MYSQLTEST_VARDIR/tmp/mysecret_keyring_backup
 
-ALTER TABLE t1 encryption_key_id=5;
-ALTER TABLE t2 encryption_key_id=5;
-ALTER TABLE t3 encryption_key_id=5;
-ALTER TABLE t4 encryption_key_id=5;
-ALTER TABLE t5 encryption_key_id=5;
-ALTER TABLE t6 encryption_key_id=5;
-ALTER TABLE t8 encryption_key_id=5;
+ALTER TABLE t1 encryption_key_id = 5;
+ALTER TABLE t2 encryption_key_id = 5;
+ALTER TABLE t3 encryption_key_id = 5;
+ALTER TABLE t4 encryption_key_id = 5;
+ALTER TABLE t5 encryption_key_id = 5;
+ALTER TABLE t6 encryption_key_id = 5;
+ALTER TABLE t8 encryption_key_id = 5;
 
---list_files $MYSQLD_DATADIR/test
+--list_files $MYSQLD_DATADIR/$DB_NAME
 FLUSH TABLES t1, t2, t3, t4, t5, t6, t8 FOR EXPORT;
 
-perl;
+--perl
 do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
-ib_backup_tablespaces("test", "t1","t2","t3", "t4", "t5", "t6", "t8");
+ib_backup_tablespaces("$ENV{DB_NAME}", "t1", "t2", "t3", "t4", "t5", "t6", "t8");
 EOF
---list_files $MYSQLD_DATADIR/test
+--list_files $MYSQLD_DATADIR/$DB_NAME
 UNLOCK TABLES;
 
 ALTER TABLE t1 DISCARD TABLESPACE;
@@ -484,31 +579,31 @@ ALTER TABLE t5 DISCARD TABLESPACE;
 ALTER TABLE t6 DISCARD TABLESPACE;
 ALTER TABLE t8 DISCARD TABLESPACE;
 
-perl;
+--perl
 do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
-ib_discard_tablespaces("test", "t1","t2","t3","t4","t5","t6","t8");
-ib_restore_tablespaces("test", "t1","t2","t3","t4","t5","t6","t8");
+ib_discard_tablespaces("$ENV{DB_NAME}", "t1", "t2", "t3", "t4", "t5", "t6", "t8");
+ib_restore_tablespaces("$ENV{DB_NAME}", "t1", "t2", "t3", "t4", "t5", "t6", "t8");
 EOF
 
---let $restart_parameters=restart:--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring_backup
+--let $restart_parameters = restart:--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring_backup
 --source include/restart_mysqld.inc
 
---error ER_GET_ERRMSG
+--error ER_INTERNAL_ERROR
 ALTER TABLE t1 IMPORT TABLESPACE;
---error ER_GET_ERRMSG
+#--error ER_INTERNAL_ERROR
 ALTER TABLE t2 IMPORT TABLESPACE;
---error ER_GET_ERRMSG
+--error ER_INTERNAL_ERROR
 ALTER TABLE t3 IMPORT TABLESPACE;
---error ER_GET_ERRMSG
+--error ER_INTERNAL_ERROR
 ALTER TABLE t4 IMPORT TABLESPACE;
---error ER_GET_ERRMSG
+--error ER_INTERNAL_ERROR
 ALTER TABLE t5 IMPORT TABLESPACE;
---error ER_GET_ERRMSG
+--error ER_INTERNAL_ERROR
 ALTER TABLE t6 IMPORT TABLESPACE;
---error ER_GET_ERRMSG
+--error ER_INTERNAL_ERROR
 ALTER TABLE t8 IMPORT TABLESPACE;
 
---let $restart_parameters=restart:--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
+--let $restart_parameters = restart:--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --source include/restart_mysqld.inc
 
 DROP PROCEDURE innodb_insert_proc;

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -5718,7 +5718,7 @@ buf_page_check_corrupt(buf_page_t* bpage, fil_space_t* space)
         //TODO:Robert - to trzeba jeszcze dodać
         ut_ad(space->n_pending_ios > 0);
         //
-        DBUG_PRINT("Robert", ("Checking if page : "UINT32PF":"UINT32PF" is corrupted",
+        DBUG_PRINT("Robert", ("Checking if page : " UINT32PF ":" UINT32PF " is corrupted",
                             bpage->id.space(), bpage->id.page_no()));
 
         //ib_uint32_t space_id = bpage->id.space();

--- a/storage/innobase/buf/buf0rea.cc
+++ b/storage/innobase/buf/buf0rea.cc
@@ -918,6 +918,7 @@ buf_read_ibuf_merge_pages(
 			tablespace: remove the entries for that page */
 			ibuf_merge_or_delete_for_page(NULL, page_id,
 						      &page_size, FALSE);
+			// fallthrough
 		case DB_PAGE_CORRUPTED:
 		case DB_DECRYPTION_FAILED:
 			ib::error() << "Failed to read or decrypt " << page_id

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -6639,6 +6639,7 @@ fil_aio_wait(
                         }
                         return;
                 }
+		// fallthrough
 	case FIL_TYPE_LOG:
 		srv_set_io_thread_op_info(segment, "complete io for log");
 		log_io_complete(static_cast<log_group_t*>(message));

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -1493,7 +1493,7 @@ os_file_compress_page(
 	*dst_len = ut_calc_align(len, block_size);
 
 	//ulint		out_len = src_len - (FIL_PAGE_DATA + block_size + ((will_be_encrypted_with_rotated_keys) ? 4 : 0));
-	ut_ad(*dst_len >= len && *dst_len <= out_len + FIL_PAGE_DATA + (will_be_encrypted_with_rotated_keys) ? 8 : 0);
+	ut_ad(*dst_len >= len && *dst_len <= out_len + FIL_PAGE_DATA + (will_be_encrypted_with_rotated_keys ? 8 : 0));
 
 	/* Clear out the unused portion of the page. */
 	if (len % block_size) {


### PR DESCRIPTION
* Removed remainings of $MTR_SUITE_DIR as it does not work as expected after cherry-picking fomr MariaDB.
* Fixed / refactored / re-recorded 'encryption.innodb_encryption_discard_import' MTR test case.
* Various GCC 7.3/8.0 fixes