### PR TITLE
Fixes for memory leaks in Rotated Keys implementation

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -4615,10 +4615,6 @@ sub run_testcase ($) {
   # -------------------------------------------------------
   my $timezone= timezone($tinfo);
   $ENV{'TZ'}= $timezone;
-  $ENV{MTR_SUITE_DIR} = $tinfo->{suite}->{dir};
-
-  mtr_verbose("MTR_SUITE_DIR: '$tinfo->{suite}->{dir}'");
-
   mtr_verbose("Setting timezone: $timezone");
 
   if ( ! using_extern() )

--- a/mysql-test/suite/encryption/r/encrypt_and_grep.result
+++ b/mysql-test/suite/encryption/r/encrypt_and_grep.result
@@ -134,7 +134,7 @@ INNODB_SYS_TABLES	CREATE TEMPORARY TABLE `INNODB_SYS_TABLES` (
 # t4 no  on expecting NOT FOUND
 # ibdata1 expecting NOT FOUND
 # ts_encrypted expecting NOT FOUND
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/tmp/mysecret_keyring --plugin-dir=/home/rob/git/5.7_rotated_tablespaces_bld/plugin/keyring --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
+# restart:<hidden args>
 # Now turn off encryption and wait for threads to decrypt everything
 SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Only three tables should stayed encrypted - the ones with explicite encryption
@@ -144,7 +144,7 @@ include/assert.inc [Only two tables should stayed encrypted - the ones with expl
 # t3 no  on expecting FOUND
 # t1 yes on expecting NOT FOUND
 # ibdata1 expecting NOT FOUND
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/tmp/mysecret_keyring --plugin-dir=/home/rob/git/5.7_rotated_tablespaces_bld/plugin/keyring --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:<hidden args>
 # Now turn on encryption and wait for threads to encrypt all spaces
 SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces
@@ -154,7 +154,7 @@ include/assert.inc [Only one table should stay unencrypted i.e. t3]
 # t3 no  on expecting FOUND
 # t1 yes on expecting NOT FOUND
 # ibdata1 expecting NOT FOUND
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/tmp/mysecret_keyring --plugin-dir=/home/rob/git/5.7_rotated_tablespaces_bld/plugin/keyring --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:<hidden args>
 alter table t1 encryption='n';
 alter table t4 encryption='n';
 # Wait max 10 min for key encryption threads to encrypt all spaces (apart from t1,t3 and t4)
@@ -164,6 +164,6 @@ include/assert.inc [All spaces apart from t1, t3 and t4 should got encrypted]
 # t3 no  on expecting FOUND
 # t4 no  on expecting FOUND
 # ibdata1 expecting NOT FOUND
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/tmp/mysecret_keyring --plugin-dir=/home/rob/git/5.7_rotated_tablespaces_bld/plugin/keyring --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:<hidden args>
 drop table t1, t2, t3, t4, t5, t6;
 drop tablespace ts_encrypted;

--- a/mysql-test/suite/encryption/r/innodb-bad-key-change.result
+++ b/mysql-test/suite/encryption/r/innodb-bad-key-change.result
@@ -8,7 +8,7 @@ call mtr.add_suppression("\\[Warning\\] InnoDB: Table is encrypted but encryptio
 call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot save statistics for table `test`\.`t2` because file \./test/t2\.ibd cannot be decrypted\.");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Table in tablespace is encrypted but encryption service or used key_id is not available\.  Can't continue reading table\.");
 # Start server with keys2.txt
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys2.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys2.txt
 SET GLOBAL innodb_file_per_table = ON;
 CREATE TABLE t1 (c VARCHAR(8)) ENGINE=InnoDB ENCRYPTION='ROTATED_KEYS' ENCRYPTION_KEY_ID=2;
 INSERT INTO t1 VALUES ('foobar');
@@ -30,20 +30,20 @@ foobar	1
 foobar	2
 
 # Restart server with keysbad3.txt
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keysbad3.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keysbad3.txt
 SELECT * FROM t1;
 ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keysbad3.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keysbad3.txt
 DROP TABLE t1;
 # Start server with keys3.txt
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys3.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys3.txt
 SET GLOBAL innodb_stats_persistent=OFF;
 SET SESSION innodb_default_encryption_key_id=5;
 CREATE TABLE t2 (c VARCHAR(8), id int not null primary key, b int, key(b)) ENGINE=InnoDB ENCRYPTION='ROTATED_KEYS';
 INSERT INTO t2 VALUES ('foobar',1,2);
 
 # Restart server with keys2.txt
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys2.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys2.txt
 SET GLOBAL innodb_stats_persistent=ON;
 SELECT * FROM t2;
 ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
@@ -76,4 +76,4 @@ ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be
 DROP TABLE t2;
 
 # Start server with keys2.txt
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys2.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys2.txt

--- a/mysql-test/suite/encryption/r/innodb-bad-key-change4.result
+++ b/mysql-test/suite/encryption/r/innodb-bad-key-change4.result
@@ -2,11 +2,11 @@ call mtr.add_suppression("InnoDB: The page \\[page id: space=[1-9][0-9]*, page n
 call mtr.add_suppression("failed to read or decrypt \\[page id: space=[1-9][0-9]*, page number=[1-9][0-9]*\\]");
 call mtr.add_suppression("\\[Error\\] InnoDB: Page is still encrypted");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Table is encrypted but encryption service or used key_id is not available\.  Can't continue reading table\.");
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys2.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys2.txt
 SET GLOBAL innodb_file_per_table = ON;
 CREATE TABLE t1 (pk INT PRIMARY KEY, f VARCHAR(8)) ENGINE=InnoDB ENCRYPTION='ROTATED_KEYS' ENCRYPTION_KEY_ID=4;
 INSERT INTO t1 VALUES (1,'foo'),(2,'bar');
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys3.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys3.txt
 OPTIMIZE TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
@@ -23,6 +23,6 @@ test.t1	check	Warning	Table test/t1 is encrypted but encryption service or used 
 test.t1	check	error	Corrupt
 SHOW WARNINGS;
 Level	Code	Message
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys2.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys2.txt
 call mtr.add_suppression("\\[Warning\\] InnoDB: Table in tablespace is encrypted .*");
 DROP TABLE t1;

--- a/mysql-test/suite/encryption/r/innodb-missing-key.result
+++ b/mysql-test/suite/encryption/r/innodb-missing-key.result
@@ -509,7 +509,7 @@ INSERT INTO t2 SELECT * FROM t1;
 INSERT INTO t3 SELECT * FROM t1;
 
 # Restart server with keys3.txt
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys3.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys3.txt
 set global innodb_encryption_rotate_key_age = 1;
 use test;
 CREATE TABLE t4(a int not null primary key, b varchar(128)) engine=innodb ENCRYPTION='ROTATED_KEYS' ENCRYPTION_KEY_ID=6;
@@ -530,7 +530,7 @@ SELECT COUNT(1) FROM t1;
 ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
 
 # Start server with keys2.txt
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys2.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys2.txt
 SELECT COUNT(1) FROM t1;
 COUNT(1)
 500

--- a/mysql-test/suite/encryption/r/innodb-read-only.result
+++ b/mysql-test/suite/encryption/r/innodb-read-only.result
@@ -1,0 +1,4 @@
+# Wait max 10 min for key encryption threads to encrypt all spaces
+# Success!
+# restart:--innodb-read-only=1 --innodb-encrypt-tables=ONLINE_TO_KEYRING
+# All done

--- a/mysql-test/suite/encryption/r/innodb_page_encryption_key_change.result
+++ b/mysql-test/suite/encryption/r/innodb_page_encryption_key_change.result
@@ -1,5 +1,5 @@
 # Restart mysqld --loose-file-key-management-filename=keys2.txt
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys2.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys2.txt
 create table innodb_normal(c1 bigint not null, b char(200)) engine=innodb;
 show warnings;
 Level	Code	Message
@@ -75,7 +75,7 @@ variable_value >= 0
 Warnings:
 Warning	1287	'INFORMATION_SCHEMA.GLOBAL_STATUS' is deprecated and will be removed in a future release. Please use performance_schema.global_status instead
 # Restart mysqld --loose-file-key-management-filename=keys3.txt
-# restart:--keyring-file-data=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/std_data/keys3.txt
+# restart:--keyring-file-data=<MYSQLTEST_VARDIR>/std_data/keys3.txt
 select * from innodb_normal;
 c1	b
 1	test1

--- a/mysql-test/suite/encryption/r/uninstall_keyring.result
+++ b/mysql-test/suite/encryption/r/uninstall_keyring.result
@@ -34,7 +34,7 @@ SET GLOBAL innodb_encryption_threads=4;
 SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Wait max 10 min for key encryption threads to decrypt all spaces
 # Restart with keyring plugin installed but not functional (impossible keyring file path). Enabling encryption threads should not be possible as well as creating tables encrypted with ROTATED_KEYS.
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=../../../../../../../mysecret_keyring --plugin-dir=/home/rob/git/5.7_rotated_tablespaces_bld/plugin/keyring --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0 --log-error=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/tmp/my_restart.err --innodb-encrypt-tables=OFF
+# restart:<hidden args>
 SET GLOBAL innodb_encryption_threads=1;
 ERROR HY000: InnoDB: keyring plugin is installed but it seems it was not properly initialized. Cannot enable encryption threads.
 CREATE TABLE t1 (a varchar(255)) engine=innodb encryption='ROTATED_KEYS';
@@ -58,7 +58,7 @@ INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 Warnings:
 Warning	29	File '../../../../../../../mysecret_keyring' not found (Errcode: 13 - Permission denied)
 SET @@global.keyring_file_data= 'MYSQL_TMP_DIR/mysecret_keyring';
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=../../../../../../../mysecret_keyring --plugin-dir=/home/rob/git/5.7_rotated_tablespaces_bld/plugin/keyring --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0 --log-error=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/tmp/my_restart.err
+# restart:<hidden args>
 ALTER TABLE t2 ENCRYPTION='N';
 ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
 DROP TABLE t1,t2,t_mk;
@@ -74,12 +74,12 @@ CREATE TABLE t5 (a varchar(255)) engine=innodb;
 INSERT t5 VALUES (repeat('foobarsecret', 12));
 CREATE TABLE t6 (a varchar(255)) engine=innodb;
 INSERT t6 VALUES (repeat('foobarsecret', 12));
-SET @@global.keyring_file_data= '/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/tmp/mysecret_keyring';
+SET @@global.keyring_file_data= 'MYSQL_TMP_DIR/mysecret_keyring';
 SET GLOBAL innodb_encryption_threads=3;
 SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
 CREATE TABLE t7 (a varchar(255)) engine=innodb;
 INSERT t7 VALUES (repeat('foobarsecret', 12));
 SET GLOBAL innodb_encryption_threads=0;
 UNINSTALL PLUGIN keyring_file;
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0 --log-error=/home/rob/git/5.7_rotated_tablespaces_bld/mysql-test/var/tmp/my_restart.err
+# restart:<hidden args>
 DROP TABLE t1,t2,t3,t4,t5,t6,t7;

--- a/mysql-test/suite/encryption/t/encrypt_and_grep.test
+++ b/mysql-test/suite/encryption/t/encrypt_and_grep.test
@@ -147,7 +147,8 @@ SHOW CREATE TABLE INFORMATION_SCHEMA.INNODB_SYS_TABLES;
 
 
 --let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
--- source include/start_mysqld.inc
+--let $restart_hide_args=1
+--source include/start_mysqld.inc
 
 --echo # Now turn off encryption and wait for threads to decrypt everything
 
@@ -233,8 +234,8 @@ SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 
 --let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
-
--- source include/start_mysqld.inc
+--let $restart_hide_args=1
+--source include/start_mysqld.inc
 
 --echo # Now turn on encryption and wait for threads to encrypt all spaces
 SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
@@ -287,6 +288,7 @@ SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
 --let SEARCH_PATTERN=moresecret
 --source include/search_pattern_in_file.inc
 
+--let $restart_hide_args=1
 --source include/start_mysqld.inc
 
 alter table t1 encryption='n';
@@ -351,6 +353,7 @@ alter table t4 encryption='n';
 --let SEARCH_PATTERN=moresecret
 --source include/search_pattern_in_file.inc
 
+--let $restart_hide_args=1
 --source include/start_mysqld.inc
 
 drop table t1, t2, t3, t4, t5, t6;

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change.test
@@ -21,6 +21,7 @@ call mtr.add_suppression("\\[Warning\\] InnoDB: Table in tablespace is encrypted
 
 --echo # Start server with keys2.txt
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
 --source include/restart_mysqld.inc
 
 SET GLOBAL innodb_file_per_table = ON;
@@ -40,6 +41,7 @@ SELECT * FROM t1;
 --echo
 --echo # Restart server with keysbad3.txt
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keysbad3.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
 --source include/restart_mysqld.inc
 
 --disable_warnings
@@ -47,8 +49,9 @@ SELECT * FROM t1;
 SELECT * FROM t1;
 --enable_warnings
 
--- let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keysbad3.txt
--- source include/restart_mysqld.inc
+--let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keysbad3.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
+--source include/restart_mysqld.inc
 
 --disable_warnings
 --replace_regex /tablespace [0-9]*/tablespace /
@@ -61,8 +64,9 @@ DROP TABLE t1;
 #
 
 --echo # Start server with keys3.txt
--- let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
--- source include/restart_mysqld.inc
+--let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
+--source include/restart_mysqld.inc
 
 SET GLOBAL innodb_stats_persistent=OFF;
 
@@ -73,8 +77,9 @@ INSERT INTO t2 VALUES ('foobar',1,2);
 
 --echo
 --echo # Restart server with keys2.txt
--- let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
--- source include/restart_mysqld.inc
+--let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
+--source include/restart_mysqld.inc
 
 SET GLOBAL innodb_stats_persistent=ON;
 
@@ -116,5 +121,6 @@ DROP TABLE t2;
 
 --echo
 --echo # Start server with keys2.txt
--- let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
--- source include/restart_mysqld.inc
+--let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
+--source include/restart_mysqld.inc

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change4.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change4.test
@@ -13,6 +13,7 @@ call mtr.add_suppression("\\[Error\\] InnoDB: Page is still encrypted");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Table is encrypted but encryption service or used key_id is not available\.  Can't continue reading table\.");
 
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
 --source include/restart_mysqld.inc
 
 SET GLOBAL innodb_file_per_table = ON;
@@ -23,9 +24,11 @@ INSERT INTO t1 VALUES (1,'foo'),(2,'bar');
 
 
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
 --source include/restart_mysqld.inc
 
 #--let $restart_parameters=--plugin-load-add=file_key_management.so --file-key-management --file-key-management-filename=$MYSQLTEST_VARDIR/std_data/keys3.txt
+#--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
 #--source include/restart_mysqld.inc
 
 #SET GLOBAL innodb_stats_persistent=OFF;
@@ -40,11 +43,13 @@ CHECK TABLE t1;
 SHOW WARNINGS;
 
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
 --source include/restart_mysqld.inc
 
 call mtr.add_suppression("\\[Warning\\] InnoDB: Table in tablespace is encrypted .*");
 #SET GLOBAL innodb_stats_persistent=OFF;
 #--let $restart_parameters=--plugin-load-add=file_key_management.so --file-key-management --file-key-management-filename=$MYSQLTEST_VARDIR/std_data/keys2.txt
+#--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
 #--source include/restart_mysqld.inc
 
 DROP TABLE t1;

--- a/mysql-test/suite/encryption/t/innodb-missing-key.test
+++ b/mysql-test/suite/encryption/t/innodb-missing-key.test
@@ -13,6 +13,7 @@ call mtr.add_suppression("\\[Error\\] InnoDB: Page is still encrypted");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Table is encrypted but encryption service or used key_id is not available\.  Can't continue reading table\.");
 
 #--echo # Start server with keys2.tx
+#--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
 #--let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
 #--source include/restart_mysqld.inc
 
@@ -53,6 +54,7 @@ INSERT INTO t3 SELECT * FROM t1;
 --echo
 --echo # Restart server with keys3.txt
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
 --source include/restart_mysqld.inc
 
 set global innodb_encryption_rotate_key_age = 1;
@@ -72,6 +74,7 @@ SELECT COUNT(1) FROM t1;
 --echo
 --echo # Start server with keys2.txt
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
 --source include/restart_mysqld.inc
 
 SELECT COUNT(1) FROM t1;

--- a/mysql-test/suite/encryption/t/innodb_page_encryption_key_change.test
+++ b/mysql-test/suite/encryption/t/innodb_page_encryption_key_change.test
@@ -13,7 +13,8 @@
 --echo # Restart mysqld --loose-file-key-management-filename=keys2.txt
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
 #-- let $restart_parameters=--loose-file-key-management-filename=$MYSQLTEST_VARDIR/std_data/keys2.txt
--- source include/restart_mysqld.inc
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
+--source include/restart_mysqld.inc
 
 create table innodb_normal(c1 bigint not null, b char(200)) engine=innodb;
 show warnings;
@@ -54,7 +55,8 @@ SELECT variable_value >= 0 FROM information_schema.global_status WHERE variable_
 --echo # Restart mysqld --loose-file-key-management-filename=keys3.txt
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
 #-- let $restart_parameters=--loose-file-key-management-filename=$MYSQLTEST_VARDIR/std_data/keys3.txt
--- source include/restart_mysqld.inc
+--replace_result $MYSQLTEST_VARDIR <MYSQLTEST_VARDIR>
+--source include/restart_mysqld.inc
 
 select * from innodb_normal;
 select * from innodb_compact;

--- a/mysql-test/suite/encryption/t/uninstall_keyring.test
+++ b/mysql-test/suite/encryption/t/uninstall_keyring.test
@@ -88,6 +88,7 @@ SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 --echo # Restart with keyring plugin installed but not functional (impossible keyring file path). Enabling encryption threads should not be possible as well as creating tables encrypted with ROTATED_KEYS.
 
 --let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=../../../../../../../mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0 --log-error=$error_log --innodb-encrypt-tables=OFF
+--let $restart_hide_args=1
 --source include/restart_mysqld.inc
 
 # Check that keyring_file was not properly intialized by checking error log
@@ -129,6 +130,7 @@ INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 eval SET @@global.keyring_file_data= '$MYSQL_TMP_DIR/mysecret_keyring';
 
 --let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=../../../../../../../mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0 --log-error=$error_log
+--let $restart_hide_args=1
 --source include/restart_mysqld.inc
 
 # keyring file is not functional, try droping t2 encryption
@@ -151,6 +153,7 @@ CREATE TABLE t5 (a varchar(255)) engine=innodb;
 INSERT t5 VALUES (repeat('foobarsecret', 12));
 CREATE TABLE t6 (a varchar(255)) engine=innodb;
 INSERT t6 VALUES (repeat('foobarsecret', 12));
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 eval SET @@global.keyring_file_data= '$MYSQL_TMP_DIR/mysecret_keyring';
 SET GLOBAL innodb_encryption_threads=3;
 SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
@@ -161,6 +164,7 @@ SET GLOBAL innodb_encryption_threads=0;
 UNINSTALL PLUGIN keyring_file;
 
 --let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0 --log-error=$error_log
+--let $restart_hide_args=1
 --source include/restart_mysqld.inc
 
 DROP TABLE t1,t2,t3,t4,t5,t6,t7;

--- a/mysys/system_key.c
+++ b/mysys/system_key.c
@@ -55,23 +55,18 @@ uchar* parse_system_key(const uchar *key, const size_t key_length, uint *key_ver
     my_free(version);
     return NULL; // conversion failed
   }
+  my_free(version);
 
   DBUG_ASSERT(ulong_key_version <= UINT_MAX); // sanity check
 
   *key_data_length= key_length - (key_version_length + 1); // skip ':' after key version
   if (*key_data_length == 0)
-  {
-    my_free(version);
     return NULL;
-  }
   DBUG_ASSERT(*key_data_length <= 512);
 
   *key_data= (uchar*)(my_malloc(PSI_NOT_INSTRUMENTED, sizeof(uchar)*(*key_data_length), MYF(0)));
   if (*key_data == NULL)
-  {
-    my_free(version);
     return NULL;
-  }
 
   memcpy(*key_data, key+key_version_length+1, *key_data_length); // skip ':' after key version
   *key_version= (uint)ulong_key_version;

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -6119,6 +6119,7 @@ fil_io_set_encryption(
 					//space->encryption_iv);
                 req_type.encryption_key(key,
 					key_len,
+					false,
                                         iv,
                                         key_version,
                                         key_id,
@@ -7155,6 +7156,7 @@ fil_iterate(
 		if ((iter.encryption_key != NULL || encrypted_with_rotated_keys) && offset != 0) {
 			read_request.encryption_key(encrypted_with_rotated_keys ? iter.crypt_data->tablespace_key : iter.encryption_key,
 						    ENCRYPTION_KEY_LEN,
+						    false,
 						    encrypted_with_rotated_keys ? iter.crypt_data->iv : iter.encryption_iv,
                                                     0, //TODO:Robert - maybe I should not set key version to 0 here, but to something like invalid key?
                                                     iter.encryption_key_id,
@@ -7220,6 +7222,7 @@ fil_iterate(
 		if (iter.encryption_key != NULL && offset != 0 && iter.crypt_data == NULL) {
 			write_request.encryption_key(iter.encryption_key,
 						     ENCRYPTION_KEY_LEN,
+						     false,
 						     iter.encryption_iv,
                                                      iter.encryption_key_version,
                                                      iter.encryption_key_id,
@@ -7248,6 +7251,7 @@ fil_iterate(
                                                      //iter.crypt_data->key_id);
 			write_request.encryption_key(iter.encryption_key,
 						     ENCRYPTION_KEY_LEN,
+						     false,
 						     iter.encryption_iv,
                                                      iter.encryption_key_version,
                                                      iter.crypt_data->key_id,

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -11423,6 +11423,7 @@ err_col:
 
 	if (err != DB_SUCCESS) {
 		dict_mem_table_free(table);
+		mem_heap_free(heap);
 		goto error_ret;
 	}
 

--- a/storage/innobase/include/fil0crypt.h
+++ b/storage/innobase/include/fil0crypt.h
@@ -112,6 +112,11 @@ struct st_encryption_scheme_key {
 
 // Merge it with fil_crypt_data
 struct st_encryption_scheme {
+	st_encryption_scheme() {
+	}
+
+	~st_encryption_scheme();
+
   unsigned char iv[16];
   struct st_encryption_scheme_key key[3]; //TODO : Why do I need this ?
 
@@ -127,6 +132,9 @@ struct st_encryption_scheme {
   unsigned int type; 
 
   //void (*locker)(struct st_encryption_scheme *self, int release);
+private:
+	st_encryption_scheme(const st_encryption_scheme&);
+	st_encryption_scheme& operator = (const st_encryption_scheme &);
 };
 
 /** is encryption enabled */

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -874,6 +874,10 @@ recv_sys_mem_free(void)
 #endif /* !UNIV_HOTBACKUP */
 		ut_free(recv_sys->buf);
 		ut_free(recv_sys->last_block_buf_start);
+
+		/* Call the destructor for recv_sys_t::dblwr member */
+		recv_sys->dblwr.~recv_dblwr_t();
+
 		ut_free(recv_sys);
 		recv_sys = NULL;
 	}
@@ -4638,6 +4642,7 @@ recv_dblwr_t::decrypt_sys_dblwr_pages()
 	decrypt_request.encryption_key(
 			space->encryption_key,
 			space->encryption_klen,
+			false,
 			space->encryption_iv,
                         0, 0, NULL, NULL);
 

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -840,6 +840,9 @@ recv_sys_close(void)
 		ut_free(recv_sys->buf);
 		ut_free(recv_sys->last_block_buf_start);
 
+		/* Call the destructor for recv_sys_t::dblwr member */
+		recv_sys->dblwr.~recv_dblwr_t();
+
 		mutex_free(&recv_sys->mutex);
 
 		ut_free(recv_sys);

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -5900,8 +5900,8 @@ os_file_io(
 	}
 
 
-        ulint space_id = mach_read_from_4(reinterpret_cast<byte*>(buf) + FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID);
-        ulint page_no = mach_read_from_4(reinterpret_cast<byte*>(buf) + FIL_PAGE_OFFSET);
+        // ulint space_id = mach_read_from_4(reinterpret_cast<byte*>(buf) + FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID);
+        // ulint page_no = mach_read_from_4(reinterpret_cast<byte*>(buf) + FIL_PAGE_OFFSET);
 
 	/* We do encryption after compression, since if we do encryption
 	before compression, the encrypted data will cause compression fail
@@ -5949,11 +5949,11 @@ os_file_io(
                                                                             // TODO:ten warunek nie ma sensu - najpierw spradzam czy type jest NONE w is_encrypted
                                                                             // a poźniej czy jest różny od ROTATED_KEYS ... 
         {
-          mach_write_to_4(reinterpret_cast<byte*>(buf) +  FIL_PAGE_ENCRYPTION_KEY_VERSION, 0);
-          if (space_id == 2 && page_no==3)
-          {
-            ib::error() << "Overwritten key_version with 0"  << '\n';
-          }
+          // mach_write_to_4(reinterpret_cast<byte*>(buf) +  FIL_PAGE_ENCRYPTION_KEY_VERSION, 0);
+          // if (space_id == 2 && page_no==3)
+          // {
+          //   ib::error() << "Overwritten key_version with 0"  << '\n';
+          // }
 
         }
 


### PR DESCRIPTION
* Reworked 'Encryption' class - it is now safely copiable and assignable.
* Eliminated memory leak in 'parse_system_key()'.
* Eliminated memory leak in the constructor of 'fil_space_crypt_t' class.
* Eliminated memory leak in key data stored inside 'st_encryption_scheme' class.
* Eliminated memory leak in 'Encryption::get_latest_system_key()'.
* Refactored 'TransactionAndHeapGuard' class.
* Eliminated memory leak in 'create_table_info_t::create_table_def()'.